### PR TITLE
Adds quotes around "true" value in docker-compose yaml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ data:
   image: postgres:latest
   volumes:
     - /var/lib/postgresql
-  command: true
+  command: "true"
 
 postgres:
   restart: always


### PR DESCRIPTION
The tutorial was not working for me until I modified the yaml here to add quotes around the true value. I am using docker-compose 1.4.0. 

This is the error I was getting beforehand:

```
$ docker-compose up -d
Creating orchestratingdocker_data_1...
json: cannot unmarshal bool into Go value of type string
```

I don't really know if this is the correct thing to do, but it is working for me. Feel free to close this PR if there's a better way to fix this.
